### PR TITLE
bug fix on getLinkByEnds, parameter's type

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -96,7 +96,7 @@ class NetV implements interfaces.Core {
      * @param endId1 one end id of the link (source or target)
      * @param endId2 another end id of the link (source or target)
      */
-    public getLinkByEnds(endId1, endId2) {
+    public getLinkByEnds(endId1: string, endId2: string) {
         return this.$_ends2link.get([endId1, endId2])
     }
 }


### PR DESCRIPTION
### This is a ...
- [ ] New feature
- [x] Other (bug fix)

### Description
add parameter's type on `NetV.getLinksByEnds()`

### Self check
- [x] Test passed or not need
- [x] Doc is ready or not need
- [x] Demo is provided or not need

### Additional Plan?
> If this PR related with other PR or following info. You can type here.

No