### PR TITLE
change data(): new data will cover old data

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -13,7 +13,7 @@ import { defaultConfigs } from './utils/configs'
 class NetV implements interfaces.Core {
     public $_id2node = new Map()
     public $_ends2link = new Map2()
-    public $_container = null
+    public $_container = undefined
     public $_configs = defaultConfigs
 
     private $_data: interfaces.NodeLinkData = { nodes: [], links: [] }
@@ -37,7 +37,11 @@ class NetV implements interfaces.Core {
         if (nodeLinkData === undefined) {
             return this.$_data
         } else {
+            // delete old data
             this.$_data = nodeLinkData
+            this.$_id2node = new Map()
+            this.$_ends2link = new Map2()
+
             this.addNodes(nodeLinkData.nodes)
             this.addLinks(nodeLinkData.links)
         }

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -42,8 +42,18 @@ test('normal cases: method data', () => {
     expect(netV.$_id2node.size).toBe(3)
     expect(netV.getNodeById('2').id()).toBe('2')
     expect(netV.$_ends2link.size).toBe(3)
-    const link = netV.getLinkByEnds('2', '3')
-    expect([link.source(), link.target()]).toContain(netV.getNodeById('2'))
+    const link23 = netV.getLinkByEnds('2', '3')
+    expect([link23.source(), link23.target()]).toContain(netV.getNodeById('2'))
+
+    netV.data({
+        nodes: [{ id: '4' }, { id: '5' }],
+        links: [{ source: '5', target: '4' }]
+    })
+    expect(netV.$_id2node.size).toBe(2)
+    expect(netV.getNodeById('2')).toBeUndefined()
+    expect(netV.$_ends2link.size).toBe(1)
+    const link45 = netV.getLinkByEnds('4', '5')
+    expect([link45.source(), link45.target()]).toContain(netV.getNodeById('4'))
 })
 
 test('normal cases: addNode/addLink', () => {


### PR DESCRIPTION
### This is a ...
- [x] New feature (`NetV.data()` methd can cover old data)
- [] Other (bug fix)

### Description
When you call `NetV.data(data)` again, new data will cover old data.

### Self check
- [x] Test passed or not need
- [x] Doc is ready or not need
- [x] Demo is provided or not need

### Additional Plan?
> If this PR related with other PR or following info. You can type here.

No