### PR TITLE
fix: 🐛 transformGraphPosition (mid position)

### DIFF
--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -26,9 +26,8 @@ export function transformGraphPosition(
     const yMin = Math.min(...ys)
     const yMax = Math.max(...ys)
 
-    const sum = (acc: number, x: number) => acc + x
-    const xMid = xs.reduce(sum) / xs.length
-    const yMid = ys.reduce(sum) / ys.length
+    const xMid = (xMin + xMax) / 2
+    const yMid = (yMin + yMax) / 2
 
     targetGraph.nodes.forEach((node) => {
         node.x = ((node.x - xMid) / (xMax - xMin)) * size + centerX


### PR DESCRIPTION
### This is a ...
- [x] Other (fix)

### Description
middle position is the middle of max and min, rather than the mean position of data

### Self check
- [x] Test passed or not need
- [x] Doc is ready or not need
- [x] Demo is provided or not need
