### PR TITLE
fix: 🐛 label not changed when dragging node

### DIFF
--- a/src/interaction/interaction.ts
+++ b/src/interaction/interaction.ts
@@ -98,6 +98,9 @@ export class InteractionManager {
                             (y - this.mouseDownPos.y) / this.transform.k
                     )
                     this.netv.draw()
+                    // when dragging, dynamic change label's position. because only operate on single element, it's ok to remove and recreate
+                    this.mouseDownElement.element.showLabel(false)
+                    this.mouseDownElement.element.showLabel(true)
                 }
             } else {
                 const yInv = this.netv.$_configs.height - y

--- a/src/label/label.ts
+++ b/src/label/label.ts
@@ -54,9 +54,10 @@ export class LabelManager {
         textElement.setAttribute('y', String(pos.y))
         textElement.setAttribute('text-anchor', 'start')
         textElement.setAttribute('alignment-baseline', 'middle')
+        textElement.style.userSelect = 'none' // NOTE: prevent unexpected selection when dragging node(delete and recreate textElement)
         textElement.innerHTML = text
 
-        this.$_svg.appendChild(textElement)
+        this.$_svg.prepend(textElement) // NOTE: make last added text at top
     }
 
     /**


### PR DESCRIPTION
### fix
previously, when dragging node, label's position is not updated. Now this problem is fixed.
refer to miserable-label example.

### additional plan
label is still coupled with other part, maybe need more efforts to make it better